### PR TITLE
develop -> master

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,7 @@
 commit = True
 tag = True
 tag_name = {new_version}
-current_version = 2.0.0
+current_version = 2.0.1
 
 [bumpversion:file:setup.py]
 search = version='{current_version}'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Logging utilities for Python projects
 
 <!--- Don't edit the version line below manually. Let bump2version do it for you. -->
-> Version 2.0.0
+> Version 2.0.1
 
 
 > This module provides ways of logging the input, output and errors in classes and functions It can be hooked up to graylog, printed to console or saved to a log file. It requires very little configuration.

--- a/loggo/__init__.py
+++ b/loggo/__init__.py
@@ -5,4 +5,4 @@ Simpler namespace
 # flake8: noqa
 from .loggo import Loggo
 
-__version__ = '2.0.0'  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+__version__ = '2.0.1'  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT

--- a/loggo/loggo.py
+++ b/loggo/loggo.py
@@ -60,7 +60,7 @@ class Loggo(object):
         self.config = config
         self.sublogger = None
         # these things should always end up in the extra data provided to logger
-        self.log_data = dict(loggo=True, loggo_config=dict(config))
+        self.log_data = dict(loggo=True, loggo_config=dict(config), sublogger=self.sublogger)
         self.facility = config.get('facility', 'loggo')
         self.ip = config.get('ip')
         self.port = config.get('port')

--- a/loggo/loggo.py
+++ b/loggo/loggo.py
@@ -259,6 +259,8 @@ class Loggo(object):
                 extra = dict(record.__dict__)
                 [extra.pop(attrib, None) for attrib in attributes]
                 alert = extra.get('alert')
+                loggo_self.log_data['sublogger'] = facility
+                loggo_self.sublogger = facility
                 extra['sublogger'] = facility
                 loggo_self.log(record.msg, alert, extra)
         other_loggo = logging.getLogger(facility)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(fname):
 
 setup(
     name='loggo',
-    version='2.0.0',  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+    version='2.0.1',  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
     author='Danny McDonald',
     author_email='daniel.mcdonald@bitpanda.com',
     description=('Python logging tools'),


### PR DESCRIPTION
Fix handling of internal logging errors, caused mostly when loggo is bound to a decorated function in such a way that it causes an error on signature binding.