### PR TITLE
Static method fix

### DIFF
--- a/loggo/loggo.py
+++ b/loggo/loggo.py
@@ -106,9 +106,6 @@ class Loggo(object):
             # AttributeError happens if we can't write, as with __dict__
             except AttributeError:
                 pass
-            # Unknown exceptions should currently raise
-            except Exception:
-                raise
         return cls
 
     def __call__(self, class_or_func):

--- a/loggo/loggo.py
+++ b/loggo/loggo.py
@@ -218,7 +218,7 @@ class Loggo(object):
                 try:
                     ret = function(*args, **kwargs)
                     if returned:
-                        ret_rep = self._represent_return_value(ret)
+                        ret_rep = self._represent_return_value(ret, truncate=500)
                         param_strings['return_value'] = ret_rep
                         param_strings['return_type'] = type(ret).__name__
                         self.log(returned, None, param_strings)
@@ -497,6 +497,8 @@ class Loggo(object):
         except Exception as error:
             self.log('Object could not be cast to string', 'dev', dict(error=str(error)))
             return '<<Unstringable input>>'
+        if max_length is False:
+            return obj
         # truncate and return
         return (obj[:max_length] + '...') if len(obj) > (max_length + 3) else obj
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -403,50 +403,43 @@ class TestMethods(unittest.TestCase):
 
     def test_methods_secret_not_called(self):
         with patch('logging.Logger.log') as logger:
-            method_name = '__secret__'
-            result = getattr(all_method_types, method_name)()
+            result = all_method_types.__secret__()
             self.assertTrue(result)
             logger.assert_not_called()
 
     def test_methods_public_instance(self):
         with patch('logging.Logger.log') as logger:
-            method_name = 'public'
-            result = getattr(all_method_types, method_name)()
+            result = all_method_types.public()
             self.assertTrue(result)
             self.assertEqual(logger.call_count, 2)
 
     def test_methods_classmethod_instance(self):
         with patch('logging.Logger.log') as logger:
-            method_name = 'cl'
-            result = getattr(all_method_types, method_name)()
+            result = all_method_types.cl()
             self.assertTrue(result)
             self.assertEqual(logger.call_count, 2)
 
     def test_methods_classmethod_class(self):
         with patch('logging.Logger.log') as logger:
-            method_name = 'cl'
-            result = getattr(AllMethodTypes, method_name)()
+            result = AllMethodTypes.cl()
             self.assertTrue(result)
             self.assertEqual(logger.call_count, 2)
 
     def test_methods_staticmethod_instance(self):
         with patch('logging.Logger.log') as logger:
-            method_name = 'st'
-            result = getattr(all_method_types, method_name)()
+            result = all_method_types.st()
             self.assertTrue(result)
             self.assertEqual(logger.call_count, 2)
 
     def test_methods_staticmethod_class(self):
         with patch('logging.Logger.log') as logger:
-            method_name = 'st'
-            result = getattr(AllMethodTypes, method_name)()
+            result = AllMethodTypes.st()
             self.assertTrue(result)
             self.assertEqual(logger.call_count, 2)
 
     def test_methods_double_logged_instance(self):
         with patch('logging.Logger.log') as logger:
-            method_name = 'doubled'
-            result = getattr(all_method_types, method_name)()
+            result = all_method_types.doubled()
             self.assertTrue(result)
             self.assertEqual(logger.call_count, 4)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -12,15 +12,17 @@ test_setup = dict(facility='LOGGO_TEST',
                   private_data=['mnemonic', 'priv'])
 Loggo = a_loggo(test_setup)
 
+
 @Loggo.logme
 def function_with_private_arg(priv, acceptable=True):
     return acceptable
+
 
 @Loggo.logme
 def function_with_private_kwarg(number, a_float=0.0, mnemonic=None):
     return number * a_float
 
-# we can also use loggo.__call__
+
 @Loggo
 def may_or_may_not_error_test(first, other, kwargs=None):
     """
@@ -30,6 +32,7 @@ def may_or_may_not_error_test(first, other, kwargs=None):
         raise ValueError('no good')
     else:
         return (first+other, kwargs)
+
 
 @Loggo.logme
 def aaa():
@@ -383,56 +386,56 @@ class TestLog(unittest.TestCase):
             dummy()
 
 
-class TestDecoration(unittest.TestCase):
+class TestMethods(unittest.TestCase):
 
-    def test_methods_0(self):
+    def test_methods_secret_not_called(self):
         with patch('logging.Logger.log') as logger:
             method_name = '__secret__'
             result = getattr(all_method_types, method_name)()
             self.assertTrue(result)
             logger.assert_not_called()
 
-    def test_methods_2(self):
+    def test_methods_public_instance(self):
         with patch('logging.Logger.log') as logger:
             method_name = 'public'
             result = getattr(all_method_types, method_name)()
             self.assertTrue(result)
-            logger.assert_called_once()
+            self.assertEqual(logger.call_count, 2)
 
-    def test_methods_4(self):
+    def test_methods_classmethod_instance(self):
         with patch('logging.Logger.log') as logger:
             method_name = 'cl'
             result = getattr(all_method_types, method_name)()
             self.assertTrue(result)
-            logger.assert_not_called()
+            self.assertEqual(logger.call_count, 2)
 
-    def test_methods_5(self):
+    def test_methods_classmethod_class(self):
         with patch('logging.Logger.log') as logger:
             method_name = 'cl'
             result = getattr(AllMethodTypes, method_name)()
             self.assertTrue(result)
-            logger.assert_called_once()
+            self.assertEqual(logger.call_count, 2)
 
-    def test_methods_6(self):
+    def test_methods_staticmethod_instance(self):
         with patch('logging.Logger.log') as logger:
             method_name = 'st'
             result = getattr(all_method_types, method_name)()
             self.assertTrue(result)
-            logger.assert_not_called()
+            self.assertEqual(logger.call_count, 2)
 
-    def test_methods_7(self):
+    def test_methods_staticmethod_class(self):
         with patch('logging.Logger.log') as logger:
             method_name = 'st'
             result = getattr(AllMethodTypes, method_name)()
             self.assertTrue(result)
-            logger.assert_called_once()
+            self.assertEqual(logger.call_count, 2)
 
-    def test_methods_8(self):
+    def test_methods_double_logged_instance(self):
         with patch('logging.Logger.log') as logger:
             method_name = 'doubled'
             result = getattr(all_method_types, method_name)()
             self.assertTrue(result)
-            logger.assert_not_called()
+            self.assertEqual(logger.call_count, 2)
 
 
 if __name__ == '__main__':

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -35,7 +35,35 @@ def may_or_may_not_error_test(first, other, kwargs=None):
 def aaa():
     return 'this'
 
-@Loggo.everything
+
+@Loggo
+class AllMethodTypes():
+
+    def __secret__(self):
+        """a method that should never be logged"""
+        return True
+
+    def public(self):
+        """normal method"""
+        return True
+
+    @classmethod
+    def cl(cls):
+        """class method"""
+        return True
+
+    @staticmethod
+    def st():
+        """static method"""
+        return True
+
+    def doubled(self):
+        return True
+
+all_method_types = AllMethodTypes()
+
+
+@Loggo
 class DummyClass(object):
     """
     A class with regular methods, static methods and errors
@@ -353,6 +381,58 @@ class TestLog(unittest.TestCase):
             return needed
         with self.assertRaises(TypeError):
             dummy()
+
+
+class TestDecoration(unittest.TestCase):
+
+    def test_methods_0(self):
+        with patch('logging.Logger.log') as logger:
+            method_name = '__secret__'
+            result = getattr(all_method_types, method_name)()
+            self.assertTrue(result)
+            logger.assert_not_called()
+
+    def test_methods_2(self):
+        with patch('logging.Logger.log') as logger:
+            method_name = 'public'
+            result = getattr(all_method_types, method_name)()
+            self.assertTrue(result)
+            logger.assert_called_once()
+
+    def test_methods_4(self):
+        with patch('logging.Logger.log') as logger:
+            method_name = 'cl'
+            result = getattr(all_method_types, method_name)()
+            self.assertTrue(result)
+            logger.assert_not_called()
+
+    def test_methods_5(self):
+        with patch('logging.Logger.log') as logger:
+            method_name = 'cl'
+            result = getattr(AllMethodTypes, method_name)()
+            self.assertTrue(result)
+            logger.assert_called_once()
+
+    def test_methods_6(self):
+        with patch('logging.Logger.log') as logger:
+            method_name = 'st'
+            result = getattr(all_method_types, method_name)()
+            self.assertTrue(result)
+            logger.assert_not_called()
+
+    def test_methods_7(self):
+        with patch('logging.Logger.log') as logger:
+            method_name = 'st'
+            result = getattr(AllMethodTypes, method_name)()
+            self.assertTrue(result)
+            logger.assert_called_once()
+
+    def test_methods_8(self):
+        with patch('logging.Logger.log') as logger:
+            method_name = 'doubled'
+            result = getattr(all_method_types, method_name)()
+            self.assertTrue(result)
+            logger.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -35,7 +35,6 @@ def may_or_may_not_error_test(first, other, kwargs=None):
         return (first + other, kwargs)
 
 
-
 @Loggo.logme
 def aaa():
     return 'this'
@@ -62,8 +61,11 @@ class AllMethodTypes():
         """static method"""
         return True
 
+    @Loggo
     def doubled(self):
+        """Loggo twice, bad but shouldn't kill"""
         return True
+
 
 all_method_types = AllMethodTypes()
 
@@ -446,7 +448,7 @@ class TestMethods(unittest.TestCase):
             method_name = 'doubled'
             result = getattr(all_method_types, method_name)()
             self.assertTrue(result)
-            self.assertEqual(logger.call_count, 2)
+            self.assertEqual(logger.call_count, 4)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Finally, I've figured out a way to auto-log static methods in uninstantiated classes.

`TestMethods` tries all method types, private, public, static, class and already Loggo decorated, with both an uninstantiated and an instantiated container. They now all behave as we want.