### PR TITLE
Make loggo provide similar interface as logging stdlib for manual logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ jobs:
     - stage: static-checks
       script:
         - flake8 loggo/ tests/
-        - mypy loggo/ tests/
+        - mypy loggo/ --disallow-untyped-defs
+        - mypy tests/
     - stage: test
       script:
         - python -m unittest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Changelog
 
 This log should always be updated when doing backwards incompatible changes, resulting in a major version bump. Feel free to add a log for lesser version bumps as well, but for major bumps it's a must.
 
+**unreleased major**
+-----
+- Changed
+    - `Loggo.listen_to()` no longer takes positional argument `no_graylog_disable_log`. Instead of this, the key-value-pair `'log_if_graylog_disabled': bool` can be included in the config dict when instantiating Loggo.
+    - The `error_alert` kwarg of `Loggo.events()` was renamed to `error_level` and is now expected to be integer.
+    - The signature `Loggo.log(self, message: str, alert: Optional[str] = None, extra: Optional[Dict] = None, safe: bool = False)` is now `Loggo.log(self, level: int, msg: str, extra: Optional[Dict] = None, safe: bool = False)`.
+
 4.0.0
 -----
 - Changed

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ setup = dict(facility='tester',             # name of program logging the messag
              private_data=['password'],     # list of sensitive args/kwargs
              obscured='[[[PRIVATE_DATA]]]') # string with which to obscure data
 Loggo = Loggo(setup)
-log = Loggo.log # just saves you doing Loggo.log all the time...
 ```
 
 ## Usage
@@ -42,7 +41,7 @@ log = Loggo.log # just saves you doing Loggo.log all the time...
 In other parts of the project, you should then be able to access the configured logger components with:
 
 ```python
-from tester import Loggo, log
+from tester import Loggo
 ```
 
 ### Decorators
@@ -124,19 +123,28 @@ def test():
     pass
 ```
 
-### Log function
+### Logging without decorators
 
-The standalone `log` function takes three parameters:
+For logging manually, Loggo provides methods similar to the logging functions of the `logging` standard library: `Loggo.log`, `Loggo.debug`, `Loggo.info`, `Loggo.warning`, `Loggo.error`, `Loggo.critical`. The methods use the configuration that has already been defined. The main method `Loggo.log` takes three parameters:
 
 ```python
-alert_level = 'dev'
-extra_data = dict(some='data', that='will', be='logged')
-log('Message to log', alert_level, extra_data)
-# console: 11.05 2018 17:36:24 Message to log  dev
+level = 50
+msg = 'Message to log'
+extra = dict(some='data', that='will', be='logged')
+Loggo.log(level, msg, extra)
+# console: 11.05 2018 17:36:24 Message to log  50
 # extra_data in log file if `do_print` setting is True
 ```
 
-It uses the configuration that has already been defined.
+Methods `Loggo.debug`, `Loggo.info`, `Loggo.warning`, `Loggo.error` and `Loggo.critical` are convenience methods for setting the log level. For instance,
+```python
+Loggo.warning('A message', dict(some='data'))
+```
+is equivalent to
+```python
+Loggo.log(logging.WARNING, 'A message', dict(some='data'))
+```
+where `logging.WARNING` is an integer constant imported from the standard library.
 
 ### Methods
 
@@ -154,8 +162,7 @@ with Loggo.pause(allow_errors=False):
 ## Tests
 
 ```bash
-cd tests
-python tests.py
+python -m unittest
 ```
 
 ## Bumping version

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ ValueError: Not authenticated!
               called='Log string for method call',
               errored='Log string on exception',
               returned='Log string for return',
-              error_alert='critical'  # alert level for errors
+              error_level=50  # log level for errors
               )
 def test():
     pass

--- a/loggo/loggo.py
+++ b/loggo/loggo.py
@@ -209,7 +209,7 @@ class Loggo:
         """
         def real_decorator(function: Callable) -> Callable:
             @wraps(function)
-            def wrapper(*args, **kwargs) -> Any:
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
                 bound = self._params_to_dict(function, *args, **kwargs)
                 if bound is None:
                     return function(*args, **kwargs)
@@ -248,7 +248,7 @@ class Loggo:
             return function
 
         @wraps(function)
-        def full_decoration(*args, **kwargs) -> Any:
+        def full_decoration(*args: Any, **kwargs: Any) -> Any:
             """
             Main decorator logic. Generate a log before running the callable,
             then try to run it. If it errors, log the error. If it doesn't,
@@ -338,7 +338,7 @@ class Loggo:
         other_loggo.setLevel(Loggo.log_threshold)
         other_loggo.addHandler(LoggoHandler())
 
-    def _params_to_dict(self, function: Callable, *args, **kwargs) -> Mapping:
+    def _params_to_dict(self, function: Callable, *args: Any, **kwargs: Any) -> Mapping:
         """
         Turn args and kwargs into an OrderedDict of {param_name: value}
         """
@@ -448,7 +448,7 @@ class Loggo:
             strung = f'{strung} -- see below: \n{trace}\n'
         return strung.strip('\n') + '\n'
 
-    def get_logfile(self, **kwargs) -> str:
+    def get_logfile(self, **kwargs: str) -> str:
         """
         This method exists so that it can be overwritten for applications requiring
         more complex logfile choices.
@@ -564,17 +564,17 @@ class Loggo:
             if self.raise_logging_errors:
                 raise
 
-    def debug(self, *args, **kwargs) -> None:
+    def debug(self, *args: Any, **kwargs: Any) -> None:
         return self.log(logging.DEBUG, *args, **kwargs)
 
-    def info(self, *args, **kwargs) -> None:
+    def info(self, *args: Any, **kwargs: Any) -> None:
         return self.log(logging.INFO, *args, **kwargs)
 
-    def warning(self, *args, **kwargs) -> None:
+    def warning(self, *args: Any, **kwargs: Any) -> None:
         return self.log(logging.WARNING, *args, **kwargs)
 
-    def error(self, *args, **kwargs) -> None:
+    def error(self, *args: Any, **kwargs: Any) -> None:
         return self.log(logging.ERROR, *args, **kwargs)
 
-    def critical(self, *args, **kwargs) -> None:
+    def critical(self, *args: Any, **kwargs: Any) -> None:
         return self.log(logging.CRITICAL, *args, **kwargs)

--- a/loggo/loggo.py
+++ b/loggo/loggo.py
@@ -310,7 +310,7 @@ class Loggo:
         Represent the call as a string mimicking how it is written in Python
         """
         signature = '{callable}({params})'
-        param_str = ', '.join('{}={}'.format(k, v) for k, v in param_strings.items())
+        param_str = ', '.join(f'{k}={v}' for k, v in param_strings.items())
         format_strings = dict(callable=getattr(function, '__qualname__', 'unknown_callable'),
                               params=param_str)
         formatted = signature.format(**format_strings)
@@ -367,7 +367,7 @@ class Loggo:
                 out[key] = self._obscure_private_keys(value, dict_depth + 1)
         return out
 
-    def _represent_return_value(self, response, truncate=140):
+    def _represent_return_value(self, response: Any, truncate: Optional[int] = 140) -> str:
         """
         Make a string representation of whatever a method returns
         """
@@ -403,7 +403,7 @@ class Loggo:
 
         # return value for log message
         if where == 'post':
-            ret_str = self._represent_return_value(returned, truncate=False)
+            ret_str = self._represent_return_value(returned, truncate=None)
             formatters['return_value'] = ret_str
             formatters['return_type'] = type(returned).__name__
 
@@ -445,7 +445,7 @@ class Loggo:
         datapoints = [tstamp, msg, level]
         strung = '\t' + '\t'.join([str(s).strip('\n') for s in datapoints])
         if trace:
-            strung = '{} -- see below: \n{}\n'.format(strung, trace)
+            strung = f'{strung} -- see below: \n{trace}\n'
         return strung.strip('\n') + '\n'
 
     def get_logfile(self, **kwargs):

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,4 @@
 license_file = LICENSE
 
 [flake8]
-# Ignore line too long warnings
-ignore = E501
+max-line-length = 120

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -160,7 +160,7 @@ class TestDecoration(unittest.TestCase):
             with self.assertRaises(ValueError):
                 first_test_func(5)
             (alert, logged_msg), extras = logger.call_args_list[-1]
-            self.assertEqual(logged_msg, '*Errored during first_test_func(number=5) with ValueError "Broken!"', logged_msg)
+            self.assertEqual(logged_msg, '*Errored during first_test_func(number=5) with ValueError "Broken!"')
 
     def test_log_errors(self):
         with patch('logging.Logger.log'):
@@ -177,7 +177,9 @@ class TestDecoration(unittest.TestCase):
                 may_or_may_not_error_test('astadh', 1331)
             (alert, logged_msg), extras = logger.call_args
             self.assertEqual(alert, 20)
-            self.assertEqual(logged_msg, '*Errored during may_or_may_not_error_test(first=\'astadh\', other=1331) with ValueError "no good"', logged_msg)
+            expected_msg = ('*Errored during may_or_may_not_error_test(first=\'astadh\', other=1331) '
+                            'with ValueError "no good"')
+            self.assertEqual(logged_msg, expected_msg)
 
     def test_logme_0(self):
         """
@@ -190,7 +192,9 @@ class TestDecoration(unittest.TestCase):
             (alert, logged_msg), extras = logger.call_args_list[0]
             self.assertEqual(logged_msg, '*Called may_or_may_not_error_test(first=2534, other=2466, kwargs=True)')
             (alert, logged_msg), extras = logger.call_args_list[-1]
-            self.assertEqual(logged_msg, '*Returned from may_or_may_not_error_test(first=2534, other=2466, kwargs=True) with tuple ((5000, True))', logged_msg)
+            expected_msg = ('*Returned from may_or_may_not_error_test(first=2534, other=2466, '
+                            'kwargs=True) with tuple ((5000, True))')
+            self.assertEqual(logged_msg, expected_msg)
 
     def test_logme_1(self):
         with patch('logging.Logger.log') as logger:
@@ -199,7 +203,7 @@ class TestDecoration(unittest.TestCase):
             (alert, logged_msg), extras = logger.call_args_list[0]
             self.assertEqual(logged_msg, '*Called DummyClass.add(a=1, b=2)')
             (alert, logged_msg), extras = logger.call_args_list[-1]
-            self.assertEqual('*Returned from DummyClass.add(a=1, b=2) with int (3)', logged_msg, logged_msg)
+            self.assertEqual('*Returned from DummyClass.add(a=1, b=2) with int (3)', logged_msg)
 
     def test_everything_0(self):
         with patch('logging.Logger.log') as logger:
@@ -207,14 +211,15 @@ class TestDecoration(unittest.TestCase):
             (alert, logged_msg), extras = logger.call_args_list[0]
             self.assertEqual(logged_msg, '*Called DummyClass.add_and_maybe_subtract(a=15, b=10, c=5)')
             (alert, logged_msg), extras = logger.call_args_list[-1]
-            self.assertEqual('*Returned from DummyClass.add_and_maybe_subtract(a=15, b=10, c=5) with int (20)', logged_msg, logged_msg)
+            expected_msg = '*Returned from DummyClass.add_and_maybe_subtract(a=15, b=10, c=5) with int (20)'
+            self.assertEqual(expected_msg, logged_msg)
 
     def test_everything_1(self):
         with patch('logging.Logger.log') as logger:
             result = dummy.static_method(10)
             self.assertEqual(result, 100)
             (alert, logged_msg), extras = logger.call_args_list[-1]
-            self.assertEqual('*Returned from DummyClass.static_method(number=10) with int (100)', logged_msg, logged_msg)
+            self.assertEqual('*Returned from DummyClass.static_method(number=10) with int (100)', logged_msg)
 
     def test_everything_3(self):
         with patch('logging.Logger.log') as logger:
@@ -382,7 +387,9 @@ class TestLog(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     may_or_may_not_error_test('one', 'two')
             (alert, msg), kwargs = logger.call_args
-            self.assertEqual('*Errored during may_or_may_not_error_test(first=\'one\', other=\'two\') with ValueError "no good"', msg, msg)
+            expected_msg = ('*Errored during may_or_may_not_error_test(first=\'one\', '
+                            'other=\'two\') with ValueError "no good"')
+            self.assertEqual(expected_msg, msg)
             logger.assert_called_once()
             logger.reset()
             with self.assertRaises(ValueError):


### PR DESCRIPTION
* Make loggo provide similar interface as the `logging` stdlib does for manual logging. Replace "alert" logic with logging stdlibs log levels.
* Fix `no_graylog_disable_log`

