### PR TITLE
Try out and enforce `black` for all code formatting

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,14 +5,13 @@ tag_name = {new_version}
 current_version = 5.1.0
 
 [bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
+search = version="{current_version}"
+replace = version="{new_version}"
 
 [bumpversion:file:loggo/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
 
 [bumpversion:file:README.md]
 search = > Version {current_version}
 replace = > Version {new_version}
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+default_language_version:
+    python: python3.7
+repos:
+-   repo: https://github.com/python/black
+    rev: stable
+    hooks:
+    - id: black

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ jobs:
       script:
         - flake8 loggo/ tests/
         - mypy loggo/ tests/
+        - black --check .
     - stage: test
       script:
         - coverage run -m unittest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![Build Status](https://travis-ci.org/bitpanda-labs/loggo.svg?branch=master)](https://travis-ci.org/bitpanda-labs/loggo)
 [![codecov.io](https://codecov.io/gh/bitpanda-labs/loggo/branch/master/graph/badge.svg)](https://codecov.io/gh/bitpanda-labs/loggo)
 [![LoC](https://tokei.rs/b1/github/bitpanda-labs/loggo)](https://github.com/bitpanda-labs/loggo)
+[![PyPI version](https://badge.fury.io/py/loggo.svg)](https://badge.fury.io/py/loggo)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
 # `@loggo`: automated logging for Python 3
 

--- a/loggo/__init__.py
+++ b/loggo/__init__.py
@@ -5,4 +5,4 @@ Simpler namespace
 # flake8: noqa
 from .loggo import Loggo
 
-__version__ = '5.1.0'  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+__version__ = "5.1.0"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT

--- a/loggo/loggo.py
+++ b/loggo/loggo.py
@@ -19,10 +19,12 @@ except ImportError:
     graypy = None
 
 # Strings to be formatted for pre function, post function and error during function
-DEFAULT_FORMS = dict(called='*Called {call_signature}',
-                     returned='*Returned from {call_signature} with {return_type} {return_value}',
-                     returned_none='*Returned None from {call_signature}',
-                     errored='*Errored during {call_signature} with {exception_type} "{exception_msg}"')
+DEFAULT_FORMS = dict(
+    called="*Called {call_signature}",
+    returned="*Returned from {call_signature} with {return_type} {return_value}",
+    returned_none="*Returned None from {call_signature}",
+    errored='*Errored during {call_signature} with {exception_type} "{exception_msg}"',
+)
 DEFAULT_LOG_LEVEL = logging.INFO
 
 
@@ -30,30 +32,33 @@ class Loggo:
     """
     A class for logging
     """
+
     # Callables with an attribute of this name set to True will not be logged by Loggo
-    no_logs_attribute_name = '_do_not_log_this_callable'
+    no_logs_attribute_name = "_do_not_log_this_callable"
     # Only log when log level is this or higher
     log_threshold = logging.DEBUG
 
-    def __init__(self,
-                 *,  # Reject positional arguments
-                 called: Optional[str] = DEFAULT_FORMS['called'],
-                 returned: Optional[str] = DEFAULT_FORMS['returned'],
-                 returned_none: Optional[str] = DEFAULT_FORMS['returned_none'],
-                 errored: Optional[str] = DEFAULT_FORMS['errored'],
-                 error_level: int = DEFAULT_LOG_LEVEL,
-                 facility: str = 'loggo',
-                 ip: Optional[str] = None,
-                 port: Optional[int] = None,
-                 do_print: bool = False,
-                 do_write: bool = False,
-                 truncation: int = 7500,
-                 raise_logging_errors: bool = False,
-                 logfile: str = './logs/logs.txt',
-                 obscured: str = '********',
-                 private_data: Optional[Set[str]] = None,
-                 max_dict_depth: int = 5,
-                 log_if_graylog_disabled: bool = True) -> None:
+    def __init__(
+        self,
+        *,  # Reject positional arguments
+        called: Optional[str] = DEFAULT_FORMS["called"],
+        returned: Optional[str] = DEFAULT_FORMS["returned"],
+        returned_none: Optional[str] = DEFAULT_FORMS["returned_none"],
+        errored: Optional[str] = DEFAULT_FORMS["errored"],
+        error_level: int = DEFAULT_LOG_LEVEL,
+        facility: str = "loggo",
+        ip: Optional[str] = None,
+        port: Optional[int] = None,
+        do_print: bool = False,
+        do_write: bool = False,
+        truncation: int = 7500,
+        raise_logging_errors: bool = False,
+        logfile: str = "./logs/logs.txt",
+        obscured: str = "********",
+        private_data: Optional[Set[str]] = None,
+        max_dict_depth: int = 5,
+        log_if_graylog_disabled: bool = True,
+    ) -> None:
         """
         On instantiation, pass in a dictionary containing the config. Currently
         accepted config values are:
@@ -106,10 +111,10 @@ class Loggo:
         if not returned_none or not returned:
             return None
         # if they provided their own, use that
-        if returned_none != DEFAULT_FORMS['returned_none']:
+        if returned_none != DEFAULT_FORMS["returned_none"]:
             return returned_none
         # if the user just used the defaults, use those
-        if returned == DEFAULT_FORMS['returned']:
+        if returned == DEFAULT_FORMS["returned"]:
             return returned_none
         # the switch: use the user provided returned for returned_none
         return returned
@@ -120,10 +125,10 @@ class Loggo:
 
         Must have non private name and be callable
         """
-        name = name or getattr(candidate, '__name__', None)
+        name = name or getattr(candidate, "__name__", None)
         if not name:
             return False
-        if name.startswith('__') and name.endswith('__'):
+        if name.startswith("__") and name.endswith("__"):
             return False
         if not callable(candidate):
             return False
@@ -253,21 +258,23 @@ class Loggo:
             privates = [key for key in param_strings if key not in bound]
 
             # add more format strings
-            more = dict(decorated=True,
-                        couplet=uuid.uuid1(),
-                        number_of_params=len(args) + len(kwargs),
-                        private_keys=', '.join(privates),
-                        timestamp=datetime.now().strftime('%d.%m %Y %H:%M:%S'))
+            more = dict(
+                decorated=True,
+                couplet=uuid.uuid1(),
+                number_of_params=len(args) + len(kwargs),
+                private_keys=", ".join(privates),
+                timestamp=datetime.now().strftime("%d.%m %Y %H:%M:%S"),
+            )
             formatters.update(more)
 
             # 'called' log tells you what was called and with what arguments
             if not just_errors:
-                self._generate_log('called', None, formatters, param_strings)
+                self._generate_log("called", None, formatters, param_strings)
 
             try:
                 # where the original function is actually run
                 response = function(*args, **kwargs)
-                where = 'returned_none' if response is None else 'returned'
+                where = "returned_none" if response is None else "returned"
                 # the successful return log
                 if not just_errors:
                     self._generate_log(where, response, formatters, param_strings)
@@ -275,9 +282,10 @@ class Loggo:
                 return response
             # handle any possible error
             except Exception as error:
-                formatters['traceback'] = traceback.format_exc()
-                self._generate_log('errored', error, formatters, param_strings)
+                formatters["traceback"] = traceback.format_exc()
+                self._generate_log("errored", error, formatters, param_strings)
                 raise
+
         return full_decoration
 
     def _string_params(self, non_private_params: Dict, use_repr: bool = True) -> Dict[str, str]:
@@ -286,7 +294,7 @@ class Loggo:
         """
         params = dict()
         for key, val in non_private_params.items():
-            truncation = self.truncation if key not in {'trace', 'traceback'} else None
+            truncation = self.truncation if key not in {"trace", "traceback"} else None
             safe_key = self._force_string_and_truncate(key, 50, use_repr=False)
             safe_val = self._force_string_and_truncate(val, truncation, use_repr=use_repr)
             params[safe_key] = safe_val
@@ -299,11 +307,12 @@ class Loggo:
 
         Return it within a dict containing some other format strings.
         """
-        signature = '{callable}({params})'
-        param_str = ', '.join(f'{k}={v}' for k, v in param_strings.items())
-        format_strings = dict(callable=getattr(function, '__qualname__', 'unknown_callable'),
-                              params=param_str)
-        format_strings['call_signature'] = signature.format(**format_strings)
+        signature = "{callable}({params})"
+        param_str = ", ".join(f"{k}={v}" for k, v in param_strings.items())
+        format_strings = dict(
+            callable=getattr(function, "__qualname__", "unknown_callable"), params=param_str
+        )
+        format_strings["call_signature"] = signature.format(**format_strings)
         return format_strings
 
     def listen_to(loggo_self, facility: str) -> None:
@@ -311,18 +320,36 @@ class Loggo:
         This method can hook the logger up to anything else that logs using the
         Python logging module (i.e. another logger) and steals its logs
         """
+
         class LoggoHandler(logging.Handler):
             def emit(handler_self, record: logging.LogRecord) -> None:
-                attributes = {'msg', 'created', 'msecs', 'stack_info',
-                              'levelname', 'filename', 'module', 'args',
-                              'funcName', 'process', 'relativeCreated',
-                              'exc_info', 'name', 'processName', 'threadName',
-                              'lineno', 'exc_text', 'pathname', 'thread',
-                              'levelno'}
+                attributes = {
+                    "msg",
+                    "created",
+                    "msecs",
+                    "stack_info",
+                    "levelname",
+                    "filename",
+                    "module",
+                    "args",
+                    "funcName",
+                    "process",
+                    "relativeCreated",
+                    "exc_info",
+                    "name",
+                    "processName",
+                    "threadName",
+                    "lineno",
+                    "exc_text",
+                    "pathname",
+                    "thread",
+                    "levelno",
+                }
                 extra = dict(record.__dict__)
                 [extra.pop(attrib, None) for attrib in attributes]
-                extra['sublogger'] = facility
+                extra["sublogger"] = facility
                 loggo_self.log(record.levelno, record.msg, extra)
+
         other_loggo = logging.getLogger(facility)
         other_loggo.setLevel(Loggo.log_threshold)
         other_loggo.addHandler(LoggoHandler())
@@ -335,10 +362,10 @@ class Loggo:
         bound = sig.bind(*args, **kwargs).arguments
         if bound:
             first = list(bound)[0]
-            if first == 'self':
-                bound.pop('self')
-            elif first == 'cls':
-                bound.pop('cls')
+            if first == "self":
+                bound.pop("self")
+            elif first == "cls":
+                bound.pop("cls")
         return bound
 
     def _obscure_private_keys(self, log_data: Any, dict_depth: int = 0) -> Any:
@@ -364,13 +391,11 @@ class Loggo:
         if str(type(response)) == "<class 'requests.models.Response'>":
             response = response.text
 
-        return '({})'.format(self._force_string_and_truncate(response, truncate, use_repr=True))
+        return "({})".format(self._force_string_and_truncate(response, truncate, use_repr=True))
 
-    def _generate_log(self,
-                      where: str,
-                      returned: Any,
-                      formatters: Dict,
-                      safe_log_data: Dict[str, str]) -> None:
+    def _generate_log(
+        self, where: str, returned: Any, formatters: Dict, safe_log_data: Dict[str, str]
+    ) -> None:
         """
         generate message, level and log data for automated logs
 
@@ -385,33 +410,33 @@ class Loggo:
             return
 
         # if errors not to be shown and this is an error, quit
-        if not self.allow_errors and where == 'errored':
+        if not self.allow_errors and where == "errored":
             return
 
         # if state is stopped and not an error, quit
-        if self.stopped and where != 'errored':
+        if self.stopped and where != "errored":
             return
 
         # do not log loggo, because why would you ever want that?
-        if 'loggo.loggo' in formatters['call_signature']:
+        if "loggo.loggo" in formatters["call_signature"]:
             return
 
         # return value for log message
-        if 'returned' in where:
+        if "returned" in where:
             ret_str = self._represent_return_value(returned, truncate=None)
-            formatters['return_value'] = ret_str
-            formatters['return_type'] = type(returned).__name__
+            formatters["return_value"] = ret_str
+            formatters["return_type"] = type(returned).__name__
 
         # if what is 'returned' is an exception, get the error formatters
-        if where == 'errored':
-            formatters['exception_type'] = type(returned).__name__
-            formatters['exception_msg'] = str(returned)
-            formatters['level'] = self.error_level
+        if where == "errored":
+            formatters["exception_type"] = type(returned).__name__
+            formatters["exception_msg"] = str(returned)
+            formatters["level"] = self.error_level
         else:
-            formatters['level'] = DEFAULT_LOG_LEVEL
+            formatters["level"] = DEFAULT_LOG_LEVEL
 
         # format the string template
-        msg = msg.format(**formatters).replace('  ', ' ')
+        msg = msg.format(**formatters).replace("  ", " ")
 
         # make the log data
         log_data = {**formatters, **safe_log_data}
@@ -440,13 +465,13 @@ class Loggo:
         needed_dir = os.path.dirname(self.logfile)
         if needed_dir and not os.path.isdir(needed_dir):
             os.makedirs(os.path.dirname(self.logfile))
-        with open(self.logfile, 'a') as fo:
-            fo.write(line.rstrip('\n') + '\n')
+        with open(self.logfile, "a") as fo:
+            fo.write(line.rstrip("\n") + "\n")
 
     def _add_graylog_handler(self) -> None:
         if not self.ip or not self.port or not graypy:
             if self.log_if_graylog_disabled:
-                self.warning('Graylog not configured! Disabling it')
+                self.warning("Graylog not configured! Disabling it")
             return
         handler = graypy.GELFUDPHandler(self.ip, self.port, debugging_fields=False)
         self.logger.addHandler(handler)
@@ -459,13 +484,14 @@ class Loggo:
         try:
             obj = str(obj) if not use_repr else repr(obj)
         except Exception as exc:
-            self.warning('Object could not be cast to string', extra=dict(exception_type=type(exc),
-                                                                          exception=exc))
-            return '<<Unstringable input>>'
+            self.warning(
+                "Object could not be cast to string", extra=dict(exception_type=type(exc), exception=exc)
+            )
+            return "<<Unstringable input>>"
         if truncate is None:
             return obj
         # truncate and return
-        return (obj[:truncate] + '...') if len(obj) > (truncate + 3) else obj
+        return (obj[:truncate] + "...") if len(obj) > (truncate + 3) else obj
 
     @staticmethod
     def _rename_protected_keys(log_data: Dict) -> Dict:
@@ -474,10 +500,10 @@ class Loggo:
         """
         out = dict()
         # names that logger will not like
-        protected = {'name', 'message', 'asctime', 'msg', 'module', 'args', 'exc_info'}
+        protected = {"name", "message", "asctime", "msg", "module", "args", "exc_info"}
         for key, value in log_data.items():
             if key in protected:
-                key = 'protected_' + key
+                key = "protected_" + key
             out[key] = value
         return out
 
@@ -522,11 +548,11 @@ class Loggo:
 
         # format logs for printing/writing to file
         if self.do_write or self.do_print:
-            ts = extra.get('timestamp', datetime.now().strftime('%d.%m %Y %H:%M:%S'))
-            line = f'{ts}\t{msg}\t{level}'
-            trace = extra.get('traceback')
+            ts = extra.get("timestamp", datetime.now().strftime("%d.%m %Y %H:%M:%S"))
+            line = f"{ts}\t{msg}\t{level}"
+            trace = extra.get("traceback")
             if trace:
-                line = f'{line} -- see below: \n{trace}\n'
+                line = f"{line} -- see below: \n{trace}\n"
         # do printing and writing to file
         if self.do_print:
             print(line)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[tool.black]
+line-length = 110
+target_version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | venv
+    | _build
+    | buck-out
+    | build
+    | dist
+  )/
+  | tester.py        # also separately exclude a file named tester.py in
+                     # the root of the project
+)
+'''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
+# Tests and CI
+pre-commit
+black
 flake8
-flake8-commas
 flake8-bugbear
 flake8-mutable
 mypy
 codecov
+
+# Requirements of the package
 graypy>=1.1.2

--- a/setup.py
+++ b/setup.py
@@ -10,19 +10,19 @@ def read(fname):
 
 
 setup(
-    name='loggo',
-    version='5.1.0',  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
-    author='Bitpanda GmbH',
-    author_email='nosupport@bitpanda.com',
-    description='Python logging tools',
-    url='https://github.com/bitpanda-labs/loggo',
-    keywords='bitpanda utilities',
-    packages=['loggo'],
-    package_data={'loggo': ['py.typed']},
+    name="loggo",
+    version="5.1.0",  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+    author="Bitpanda GmbH",
+    author_email="nosupport@bitpanda.com",
+    description="Python logging tools",
+    url="https://github.com/bitpanda-labs/loggo",
+    keywords="bitpanda utilities",
+    packages=["loggo"],
+    package_data={"loggo": ["py.typed"]},
     zip_safe=False,  # For mypy to be able to find the installed package
-    long_description=read('README.md'),
-    long_description_content_type='text/markdown',
-    install_requires=['graypy>=1.1.2,<1.2.0'],
-    python_requires='>=3.6',
-    classifiers=['Topic :: Utilities'],
+    long_description=read("README.md"),
+    long_description_content_type="text/markdown",
+    install_requires=["graypy>=1.1.2,<1.2.0"],
+    python_requires=">=3.6",
+    classifiers=["Topic :: Utilities"],
 )

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -7,9 +7,9 @@ from unittest.mock import ANY, Mock, mock_open, patch
 
 from loggo import Loggo
 
-test_setup = dict(do_write=True,
-                  log_if_graylog_disabled=False,
-                  private_data={'mnemonic', 'priv'})  # type: Mapping[str, Any]
+test_setup = dict(
+    do_write=True, log_if_graylog_disabled=False, private_data={"mnemonic", "priv"}
+)  # type: Mapping[str, Any]
 
 loggo = Loggo(**test_setup)
 
@@ -31,19 +31,18 @@ def may_or_may_not_error_test(first, other, kwargs=None):
     A function that may or may not error
     """
     if not kwargs:
-        raise ValueError('no good')
+        raise ValueError("no good")
     else:
         return (first + other, kwargs)
 
 
 @loggo
 def aaa():
-    return 'this'
+    return "this"
 
 
 @loggo
 class AllMethodTypes:
-
     def __secret__(self):
         """a method that should never be logged"""
         return True
@@ -75,8 +74,9 @@ class NoRepr:
     """
     An object that really hates being repr'd
     """
+
     def __repr__(self):
-        raise Exception('No.')
+        raise Exception("No.")
 
 
 @loggo
@@ -84,6 +84,7 @@ class DummyClass:
     """
     A class with regular methods, static methods and errors
     """
+
     non_callable = False
 
     def add(self, a, b):
@@ -101,15 +102,15 @@ class DummyClass:
 
     def optional_provided(self, kw=None, **kwargs):
         if kw:
-            raise ValueError('Should not have provided!')
+            raise ValueError("Should not have provided!")
 
     @loggo.ignore
     def hopefully_ignored(self, n):
-        return n**n
+        return n ** n
 
     @loggo.errors
     def hopefully_only_errors(self, n):
-        raise ValueError('Bam!')
+        raise ValueError("Bam!")
 
 
 class DummyClass2:
@@ -120,7 +121,7 @@ class DummyClass2:
 @loggo.errors
 class ForErrors:
     def one(self):
-        raise ValueError('Boom!')
+        raise ValueError("Boom!")
 
     def two(self):
         return True
@@ -128,17 +129,17 @@ class ForErrors:
 
 @loggo.errors
 def first_test_func(number):
-    raise ValueError('Broken!')
+    raise ValueError("Broken!")
 
 
 @loggo.errors
 def second_test_func(number):
-    raise ValueError('Broken!')
+    raise ValueError("Broken!")
 
 
 @loggo
 def test_func3(number):
-    raise ValueError('Broken!')
+    raise ValueError("Broken!")
 
 
 @loggo
@@ -150,8 +151,8 @@ def test_inner():
     return 1
 
 
-within = dict(lst=list(), ok=dict(ok=dict(priv='secret')))
-beyond = dict(lst=list(), ok=dict(ok=dict(ok=dict(ok=dict(ok=dict(ok=dict(priv='allowed')))))))
+within = dict(lst=list(), ok=dict(ok=dict(priv="secret")))
+beyond = dict(lst=list(), ok=dict(ok=dict(ok=dict(ok=dict(ok=dict(ok=dict(priv="allowed")))))))
 
 
 @loggo
@@ -168,7 +169,6 @@ dummy = DummyClass()
 
 
 class TestDecoration(unittest.TestCase):
-
     def test_decorate_module(self):
         """
         Test that a module is (currently) not altered if decorated
@@ -179,7 +179,7 @@ class TestDecoration(unittest.TestCase):
         """
         Test that an object is not altered if it's not callable
         """
-        anything = 'a string'
+        anything = "a string"
         self.assertIs(anything, loggo(anything))
 
     def test_inheritance_signature_change(self):
@@ -187,7 +187,7 @@ class TestDecoration(unittest.TestCase):
         self.assertEqual(6, d2.add(1, 2, 3))
 
     def test_errors_on_func(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             with self.assertRaises(ValueError):
                 first_test_func(5)
             (alert, logged_msg), extras = logger.call_args_list[-1]
@@ -195,7 +195,7 @@ class TestDecoration(unittest.TestCase):
             self.assertEqual(logged_msg, expected_msg)
 
     def test_log_errors(self):
-        with patch('logging.Logger.log'):
+        with patch("logging.Logger.log"):
             with self.assertRaises(ValueError):
                 with loggo.log_errors():
                     second_test_func(5)
@@ -204,97 +204,99 @@ class TestDecoration(unittest.TestCase):
         """
         Check that an error is thrown for a func
         """
-        with patch('logging.Logger.log') as logger:
-            with self.assertRaisesRegex(ValueError, 'no good'):
-                may_or_may_not_error_test('astadh', 1331)
+        with patch("logging.Logger.log") as logger:
+            with self.assertRaisesRegex(ValueError, "no good"):
+                may_or_may_not_error_test("astadh", 1331)
             (alert, logged_msg), extras = logger.call_args
             self.assertEqual(alert, 20)
-            expected_msg = ('*Errored during may_or_may_not_error_test(first=\'astadh\', '
-                            'other=1331) with ValueError "no good"')
+            expected_msg = (
+                "*Errored during may_or_may_not_error_test(first='astadh', "
+                'other=1331) with ValueError "no good"'
+            )
             self.assertEqual(logged_msg, expected_msg)
 
     def test_logme_0(self):
         """
         Test correct result
         """
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             res, kwa = may_or_may_not_error_test(2534, 2466, kwargs=True)
             self.assertEqual(res, 5000)
             self.assertTrue(kwa)
             (alert, logged_msg), extras = logger.call_args_list[0]
-            expected_msg = '*Called may_or_may_not_error_test(first=2534, other=2466, kwargs=True)'
+            expected_msg = "*Called may_or_may_not_error_test(first=2534, other=2466, kwargs=True)"
             self.assertEqual(logged_msg, expected_msg)
             (alert, logged_msg), extras = logger.call_args_list[-1]
-            expected_msg = ('*Returned from may_or_may_not_error_test(first=2534, other=2466, '
-                            'kwargs=True) with tuple ((5000, True))')
+            expected_msg = (
+                "*Returned from may_or_may_not_error_test(first=2534, other=2466, "
+                "kwargs=True) with tuple ((5000, True))"
+            )
             self.assertEqual(logged_msg, expected_msg)
 
     def test_logme_1(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             result = dummy.add(1, 2)
             self.assertEqual(result, 3)
             (alert, logged_msg), extras = logger.call_args_list[0]
-            self.assertEqual(logged_msg, '*Called DummyClass.add(a=1, b=2)')
+            self.assertEqual(logged_msg, "*Called DummyClass.add(a=1, b=2)")
             (alert, logged_msg), extras = logger.call_args_list[-1]
-            self.assertEqual('*Returned from DummyClass.add(a=1, b=2) with int (3)', logged_msg)
+            self.assertEqual("*Returned from DummyClass.add(a=1, b=2) with int (3)", logged_msg)
 
     def test_everything_0(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             dummy.add_and_maybe_subtract(15, 10, 5)
             (alert, logged_msg), extras = logger.call_args_list[0]
-            expected_msg = '*Called DummyClass.add_and_maybe_subtract(a=15, b=10, c=5)'
+            expected_msg = "*Called DummyClass.add_and_maybe_subtract(a=15, b=10, c=5)"
             self.assertEqual(logged_msg, expected_msg)
             (alert, logged_msg), extras = logger.call_args_list[-1]
-            expected_msg = ('*Returned from DummyClass.add_and_maybe_'
-                            'subtract(a=15, b=10, c=5) with int (20)')
+            expected_msg = "*Returned from DummyClass.add_and_maybe_subtract(a=15, b=10, c=5) with int (20)"
             self.assertEqual(expected_msg, logged_msg)
 
     def test_everything_1(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             result = dummy.static_method(10)
             self.assertEqual(result, 100)
             (alert, logged_msg), extras = logger.call_args_list[-1]
-            expected_msg = '*Returned from DummyClass.static_method(number=10) with int (100)'
+            expected_msg = "*Returned from DummyClass.static_method(number=10) with int (100)"
             self.assertEqual(logged_msg, expected_msg)
 
     def test_everything_3(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             dummy.optional_provided()
             (alert, logged_msg), extras = logger.call_args_list[0]
-            self.assertEqual(logged_msg, '*Called DummyClass.optional_provided()')
+            self.assertEqual(logged_msg, "*Called DummyClass.optional_provided()")
             (alert, logged_msg), extras = logger.call_args_list[-1]
-            self.assertTrue('Returned None' in logged_msg)
+            self.assertTrue("Returned None" in logged_msg)
 
     def test_everything_4(self):
-        with patch('logging.Logger.log') as logger:
-            with self.assertRaisesRegex(ValueError, 'Should not have provided!'):
-                result = dummy.optional_provided(kw='Something')
+        with patch("logging.Logger.log") as logger:
+            with self.assertRaisesRegex(ValueError, "Should not have provided!"):
+                result = dummy.optional_provided(kw="Something")
                 self.assertIsNone(result)
                 (alert, logged_msg), extras = logger.call_args_list[0]
-                self.assertTrue('0 args, 1 kwargs' in logged_msg)
+                self.assertTrue("0 args, 1 kwargs" in logged_msg)
                 (alert, logged_msg), extras = logger.call_args_list[-1]
-                self.assertTrue('Errored with ValueError' in logged_msg, logged_msg)
+                self.assertTrue("Errored with ValueError" in logged_msg, logged_msg)
 
     def test_loggo_ignore(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             result = dummy.hopefully_ignored(5)
-            self.assertEqual(result, 5**5)
+            self.assertEqual(result, 5 ** 5)
             logger.assert_not_called()
 
     def test_loggo_errors(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             with self.assertRaises(ValueError):
                 dummy.hopefully_only_errors(5)
             (alert, logged_msg), extras = logger.call_args
-            expected_msg = ('*Errored during DummyClass.hopefully_only_'
-                            'errors(n=5) with ValueError "Bam!"')
+            expected_msg = '*Errored during DummyClass.hopefully_only_errors(n=5) with ValueError "Bam!"'
             self.assertEqual(expected_msg, logged_msg)
 
     def test_error_deco(self):
         """
         Test that @loggo.errors logs only errors when decorating a class
         """
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             fe = ForErrors()
             self.assertTrue(fe.two())
             logger.assert_not_called()
@@ -305,38 +307,37 @@ class TestDecoration(unittest.TestCase):
             self.assertEqual(logged_msg, '*Errored during ForErrors.one() with ValueError "Boom!"')
 
     def test_private_keyword_removal(self):
-        with patch('logging.Logger.log') as logger:
-            mnem = 'every good boy deserves fruit'
+        with patch("logging.Logger.log") as logger:
+            mnem = "every good boy deserves fruit"
             res = function_with_private_kwarg(10, a_float=5.5, mnemonic=mnem)
             self.assertEqual(res, 10 * 5.5)
             (_alert, _logged_msg), extras = logger.call_args_list[0]
-            self.assertEqual(extras['extra']['mnemonic'], "'********'")
+            self.assertEqual(extras["extra"]["mnemonic"], "'********'")
 
     def test_private_positional_removal(self):
-        with patch('logging.Logger.log') as logger:
-            res = function_with_private_arg('should not log', False)
+        with patch("logging.Logger.log") as logger:
+            res = function_with_private_arg("should not log", False)
             self.assertFalse(res)
             (_alert, _logged_msg), extras = logger.call_args_list[0]
-            self.assertEqual(extras['extra']['priv'], "'********'")
+            self.assertEqual(extras["extra"]["priv"], "'********'")
 
     def test_private_beyond(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             test_func_with_recursive_data_beyond(beyond)
             (_alert, _logged_msg), extras = logger.call_args_list[0]
-            self.assertTrue('allowed' in extras['extra']['data'])
+            self.assertTrue("allowed" in extras["extra"]["data"])
 
     def test_private_within(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             test_func_with_recursive_data_within(within)
             (_alert, _logged_msg), extras = logger.call_args_list[0]
-            self.assertFalse('secret' in extras['extra']['data'])
+            self.assertFalse("secret" in extras["extra"]["data"])
 
 
 class TestLog(unittest.TestCase):
-
     def setUp(self):
-        self.log_msg = 'This is a message that can be used when the content does not matter.'
-        self.log_data = {'This is': 'log data', 'that can be': 'used when content does not matter'}
+        self.log_msg = "This is a message that can be used when the content does not matter."
+        self.log_data = {"This is": "log data", "that can be": "used when content does not matter"}
         self.loggo = Loggo(do_print=True, do_write=True, log_if_graylog_disabled=False)
         self.log = self.loggo.log
 
@@ -345,150 +346,152 @@ class TestLog(unittest.TestCase):
         Check that a protected name "name" is converted to "protected_name",
         in order to stop error in logger later
         """
-        with patch('logging.Logger.log') as mock_log:
-            self.log(logging.INFO, 'fine', dict(name='bad', other='good'))
+        with patch("logging.Logger.log") as mock_log:
+            self.log(logging.INFO, "fine", dict(name="bad", other="good"))
             (_alert, _msg), kwargs = mock_log.call_args
-            self.assertEqual(kwargs['extra']['protected_name'], 'bad')
-            self.assertEqual(kwargs['extra']['other'], 'good')
+            self.assertEqual(kwargs["extra"]["protected_name"], "bad")
+            self.assertEqual(kwargs["extra"]["other"], "good")
 
     def test_can_log(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             level_num = 50
-            msg = 'Test message here'
-            result = self.log(level_num, msg, dict(extra='data'))
+            msg = "Test message here"
+            result = self.log(level_num, msg, dict(extra="data"))
             self.assertIsNone(result)
             (alert, logged_msg), extras = logger.call_args
             self.assertEqual(alert, level_num)
             self.assertEqual(msg, logged_msg)
-            self.assertEqual(extras['extra']['extra'], 'data')
+            self.assertEqual(extras["extra"]["extra"], "data")
 
     def test_write_to_file(self):
         """
         Check that we can write logs to file
         """
         mock = mock_open()
-        with patch('builtins.open', mock):
-            self.log(logging.INFO, 'An entry in our log')
-            mock.assert_called_with(loggo.logfile, 'a')
+        with patch("builtins.open", mock):
+            self.log(logging.INFO, "An entry in our log")
+            mock.assert_called_with(loggo.logfile, "a")
             self.assertTrue(os.path.isfile(loggo.logfile))
 
     def test_int_truncation(self):
         """
         Log was failing to truncate big integers. Check that this is now fixed.
         """
-        with patch('logging.Logger.log') as mock_log:
-            msg = 'This is simply a test of the int truncation inside the log.'
-            large_number = 10**300001
+        with patch("logging.Logger.log") as mock_log:
+            msg = "This is simply a test of the int truncation inside the log."
+            large_number = 10 ** 300001
             log_data = dict(key=large_number)
             self.log(logging.INFO, msg, log_data)
             mock_log.assert_called_with(20, msg, extra=ANY)
-            logger_was_passed = mock_log.call_args[1]['extra']['key']
+            logger_was_passed = mock_log.call_args[1]["extra"]["key"]
             # 7500 here is the default self.truncation for loggo
-            done_by_hand = str(large_number)[:7500] + '...'
+            done_by_hand = str(large_number)[:7500] + "..."
             self.assertEqual(logger_was_passed, done_by_hand)
 
     def test_string_truncation_fail(self):
         """
         If something cannot be cast to string, we need to know about it
         """
-        with patch('logging.Logger.log') as mock_log:
+        with patch("logging.Logger.log") as mock_log:
             no_string_rep = NoRepr()
             result = self.loggo._force_string_and_truncate(no_string_rep, 7500)
-            self.assertEqual(result, '<<Unstringable input>>')
+            self.assertEqual(result, "<<Unstringable input>>")
             (alert, msg), kwargs = mock_log.call_args
-            self.assertEqual('Object could not be cast to string', msg)
+            self.assertEqual("Object could not be cast to string", msg)
 
     def test_fail_to_add_entry(self):
-        with patch('logging.Logger.log') as mock_log:
+        with patch("logging.Logger.log") as mock_log:
             no_string_rep = NoRepr()
             sample = dict(fine=123, not_fine=no_string_rep)
             result = self.loggo.sanitise(sample)
             (alert, msg), kwargs = mock_log.call_args
-            self.assertEqual('Object could not be cast to string', msg)
-            self.assertEqual(result['not_fine'], '<<Unstringable input>>')
-            self.assertEqual(result['fine'], '123')
+            self.assertEqual("Object could not be cast to string", msg)
+            self.assertEqual(result["not_fine"], "<<Unstringable input>>")
+            self.assertEqual(result["fine"], "123")
 
     def test_log_fail(self):
-        with patch('logging.Logger.log') as mock_log:
-            mock_log.side_effect = Exception('Really dead.')
+        with patch("logging.Logger.log") as mock_log:
+            mock_log.side_effect = Exception("Really dead.")
             self.loggo.raise_logging_errors = True
             with self.assertRaises(Exception):
-                self.loggo.log(logging.INFO, 'Anything')
+                self.loggo.log(logging.INFO, "Anything")
 
     def test_loggo_pause(self):
-        with patch('logging.Logger.log') as mock_log:
+        with patch("logging.Logger.log") as mock_log:
             with loggo.pause():
-                loggo.log(logging.INFO, 'test')
+                loggo.log(logging.INFO, "test")
             mock_log.assert_not_called()
-            loggo.log(logging.INFO, 'test')
+            loggo.log(logging.INFO, "test")
             mock_log.assert_called()
 
     def test_loggo_pause_error(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             with loggo.pause():
                 with self.assertRaises(ValueError):
-                    may_or_may_not_error_test('one', 'two')
+                    may_or_may_not_error_test("one", "two")
             (alert, msg), kwargs = logger.call_args
-            expected_msg = ('*Errored during may_or_may_not_error_test(first=\'one\', '
-                            'other=\'two\') with ValueError "no good"')
+            expected_msg = (
+                "*Errored during may_or_may_not_error_test(first='one', "
+                "other='two') with ValueError \"no good\""
+            )
             self.assertEqual(expected_msg, msg)
             logger.assert_called_once()
             logger.reset()
             with self.assertRaises(ValueError):
-                may_or_may_not_error_test('one', 'two')
+                may_or_may_not_error_test("one", "two")
                 self.assertEqual(len(logger.call_args_list), 2)
 
     def test_loggo_error_suppressed(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             with loggo.pause(allow_errors=False):
                 with self.assertRaises(ValueError):
-                    may_or_may_not_error_test('one', 'two')
+                    may_or_may_not_error_test("one", "two")
             logger.assert_not_called()
-            loggo.log(logging.INFO, 'test')
+            loggo.log(logging.INFO, "test")
             logger.assert_called_once()
 
     def test_see_below(self):
         """legacy test, deletable if it causes problems later"""
-        with patch('logging.Logger.log') as logger:
-            loggo.log(50, 'test')
+        with patch("logging.Logger.log") as logger:
+            loggo.log(50, "test")
             (alert, msg), kwargs = logger.call_args
-            self.assertFalse('-- see below:' in msg)
+            self.assertFalse("-- see below:" in msg)
 
     def test_compat(self):
-        test = 'a string'
-        with patch('loggo.Loggo.log') as logger:
+        test = "a string"
+        with patch("loggo.Loggo.log") as logger:
             loggo.log(logging.INFO, test, None)
         args = logger.call_args
         self.assertIsInstance(args[0][0], int)
         self.assertEqual(args[0][1], test)
         self.assertIsNone(args[0][2])
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             loggo.log(logging.INFO, test)
         (alert, msg), kwargs = logger.call_args
         self.assertEqual(test, msg)
 
     def test_bad_args(self):
-
         @loggo
         def dummy(needed):
             return needed
+
         with self.assertRaises(TypeError):
             dummy()
 
     def _working_normally(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             res = aaa()
-            self.assertEqual(res, 'this')
+            self.assertEqual(res, "this")
             self.assertEqual(logger.call_count, 2)
             (alert, logged_msg), extras = logger.call_args_list[0]
-            self.assertTrue(logged_msg.startswith('*Called'))
+            self.assertTrue(logged_msg.startswith("*Called"))
             (alert, logged_msg), extras = logger.call_args_list[-1]
-            self.assertTrue(logged_msg.startswith('*Returned'))
+            self.assertTrue(logged_msg.startswith("*Returned"))
 
     def _not_logging(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             res = aaa()
-            self.assertEqual(res, 'this')
+            self.assertEqual(res, "this")
             logger.assert_not_called()
 
     def test_stop_and_start(self):
@@ -503,39 +506,39 @@ class TestLog(unittest.TestCase):
         self._working_normally()
 
     def test_debug(self):
-        with patch('loggo.Loggo.log') as logger:
+        with patch("loggo.Loggo.log") as logger:
             self.loggo.debug(self.log_msg, self.log_data)
             logger.assert_called_with(logging.DEBUG, self.log_msg, self.log_data)
 
     def test_info(self):
-        with patch('loggo.Loggo.log') as logger:
+        with patch("loggo.Loggo.log") as logger:
             self.loggo.info(self.log_msg, self.log_data)
             logger.assert_called_with(logging.INFO, self.log_msg, self.log_data)
 
     def test_warning(self):
-        with patch('loggo.Loggo.log') as logger:
+        with patch("loggo.Loggo.log") as logger:
             self.loggo.warning(self.log_msg, self.log_data)
             logger.assert_called_with(logging.WARNING, self.log_msg, self.log_data)
 
     def test_error(self):
-        with patch('loggo.Loggo.log') as logger:
+        with patch("loggo.Loggo.log") as logger:
             self.loggo.error(self.log_msg, self.log_data)
             logger.assert_called_with(logging.ERROR, self.log_msg, self.log_data)
 
     def test_critical(self):
-        with patch('loggo.Loggo.log') as logger:
+        with patch("loggo.Loggo.log") as logger:
             self.loggo.critical(self.log_msg, self.log_data)
             logger.assert_called_with(logging.CRITICAL, self.log_msg, self.log_data)
 
     def test_listen_to(self):
-        sub_loggo_facility = 'a sub logger'
+        sub_loggo_facility = "a sub logger"
         sub_loggo = Loggo(facility=sub_loggo_facility)
         self.loggo.listen_to(sub_loggo_facility)
         self.loggo.log = Mock()
-        warn = 'The parent logger should log this message after sublogger logs it'
+        warn = "The parent logger should log this message after sublogger logs it"
         sub_loggo.log(logging.WARNING, warn)
         self.loggo.log.assert_called_with(logging.WARNING, warn, ANY)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_custom_strings.py
+++ b/tests/test_custom_strings.py
@@ -4,20 +4,20 @@ from typing import Mapping, Optional
 from loggo import Loggo
 
 # without the Mapping annotation this fails, apparently due to mypy problems
-strings = dict(called='Log string {call_signature}',
-               returned='Log string for return',
-               errored='Log string on exception')  # type: Mapping[str, str]
+strings = dict(
+    called="Log string {call_signature}", returned="Log string for return", errored="Log string on exception"
+)  # type: Mapping[str, str]
 
 custom_strings = Loggo(log_if_graylog_disabled=False, **strings)
 
-nocalled = dict(called=None,
-                returned='Log string for return',
-                returned_none='Returned none!',
-                errored='Log string on exception')  # type: Mapping[str, Optional[str]]
+nocalled = dict(
+    called=None,
+    returned="Log string for return",
+    returned_none="Returned none!",
+    errored="Log string on exception",
+)  # type: Mapping[str, Optional[str]]
 
-no_return = dict(called='called fine',
-                 returned=None,
-                 returned_none=None)  # type: Mapping[str, Optional[str]]
+no_return = dict(called="called fine", returned=None, returned_none=None)  # type: Mapping[str, Optional[str]]
 
 custom_none_string = Loggo(log_if_graylog_disabled=False, **nocalled)
 
@@ -37,7 +37,7 @@ def custom_none_user_returned():
 
 @custom_strings
 def custom_fail():
-    raise ValueError('Boom!')
+    raise ValueError("Boom!")
 
 
 @custom_none_string
@@ -51,54 +51,53 @@ def custom_without_return():
 
 
 class TestCustomStrings(unittest.TestCase):
-
     def test_pass(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             n = custom_success()
             self.assertEqual(n, 1)
             self.assertEqual(logger.call_count, 2)
             (alert, logged_msg), extras = logger.call_args_list[0]
-            self.assertEqual(logged_msg, 'Log string custom_success()')
+            self.assertEqual(logged_msg, "Log string custom_success()")
             (alert, logged_msg), extras = logger.call_args_list[1]
-            self.assertEqual(logged_msg, 'Log string for return')
+            self.assertEqual(logged_msg, "Log string for return")
 
     def test_user_default_none(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             n = custom_success()
             self.assertEqual(n, 1)
             self.assertEqual(logger.call_count, 2)
             (alert, logged_msg), extras = logger.call_args_list[0]
-            self.assertEqual(logged_msg, 'Log string custom_success()')
+            self.assertEqual(logged_msg, "Log string custom_success()")
             (alert, logged_msg), extras = logger.call_args_list[1]
-            self.assertEqual(logged_msg, 'Log string for return')
+            self.assertEqual(logged_msg, "Log string for return")
 
     def custom_none_default(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             n = custom_success()
             self.assertEqual(n, 1)
             self.assertEqual(logger.call_count, 1)
             (alert, logged_msg), extras = logger.call_args_list[1]
-            self.assertEqual(logged_msg, 'Log string for return')
+            self.assertEqual(logged_msg, "Log string for return")
 
     def test_fail(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             with self.assertRaises(ValueError):
                 custom_fail()
             self.assertEqual(logger.call_count, 2)
             (alert, logged_msg), extras = logger.call_args_list[0]
-            self.assertEqual(logged_msg, 'Log string custom_fail()')
+            self.assertEqual(logged_msg, "Log string custom_fail()")
             (alert, logged_msg), extras = logger.call_args_list[1]
-            self.assertEqual(logged_msg, 'Log string on exception')
+            self.assertEqual(logged_msg, "Log string on exception")
             self.assertEqual(alert, 20)
 
     def test_no_return_string(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             n = custom_without_return()
             self.assertEqual(n, 1)
             self.assertEqual(logger.call_count, 1)
             (alert, logged_msg), extras = logger.call_args_list[0]
-            self.assertEqual(logged_msg, 'called fine')
+            self.assertEqual(logged_msg, "called fine")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_method_types.py
+++ b/tests/test_method_types.py
@@ -8,7 +8,6 @@ loggo = Loggo(log_if_graylog_disabled=False)
 
 @loggo
 class AllMethodTypes:
-
     def __secret__(self):
         """a method that should never be logged"""
         return True
@@ -37,49 +36,48 @@ all_method_types = AllMethodTypes()
 
 
 class TestMethods(unittest.TestCase):
-
     def test_methods_secret_not_called(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             result = all_method_types.__secret__()
             self.assertTrue(result)
             logger.assert_not_called()
 
     def test_methods_public_instance(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             result = all_method_types.public()
             self.assertTrue(result)
             self.assertEqual(logger.call_count, 2)
 
     def test_methods_classmethod_instance(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             result = all_method_types.cl()
             self.assertTrue(result)
             self.assertEqual(logger.call_count, 2)
 
     def test_methods_classmethod_class(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             result = AllMethodTypes.cl()
             self.assertTrue(result)
             self.assertEqual(logger.call_count, 2)
 
     def test_methods_staticmethod_instance(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             result = all_method_types.st()
             self.assertTrue(result)
             self.assertEqual(logger.call_count, 2)
 
     def test_methods_staticmethod_class(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             result = AllMethodTypes.st()
             self.assertTrue(result)
             self.assertEqual(logger.call_count, 2)
 
     def test_methods_double_logged_instance(self):
-        with patch('logging.Logger.log') as logger:
+        with patch("logging.Logger.log") as logger:
             result = all_method_types.doubled()
             self.assertTrue(result)
             self.assertEqual(logger.call_count, 4)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I don't expect this to be merged (although would love it if it happened), but using this MR to start a discussion, and showcase how well black would do at code formatting for us. The benefits of using something like this are pretty clear, read e.g. the first introduction paragraph here: https://pypi.org/project/black/ .

Black has been gaining a lot of traction in the Python community. It's already enforced in py-test codebase, will be in Django codebase (https://twitter.com/andrewgodwin/status/1127027840296177666) and even the Python stdlib (!!!) (https://twitter.com/llanga/status/1123980467911495680). Black was moved under the Python Software Foundation (https://www.python.org/psf/) umbrella last month.

Loggo code is already decently formatted, so the formatting changes in this MR are fairly minor. Here's an example of what magic black can do to absolutely garbage code: https://black.now.sh .

I think we should very seriously consider using black, and from my own side am already willing to vote "yes".