### PR TITLE
stdlib logging can handle printing and writing to files

### DIFF
--- a/loggo/loggo.py
+++ b/loggo/loggo.py
@@ -72,10 +72,11 @@ class _Formatter(logging.Formatter):
     def __init__(self) -> None:
         super().__init__("%(asctime)s\t%(message)s\t%(levelno)s", "%Y-%m-%d %H:%M:%S %Z")
 
-    def format(self, record: logging.LogRecord) -> str:
+    def format(self, record: logging.LogRecord) -> str:  # noqa: A003
         msg = super().format(record)
-        if hasattr(record, "traceback"):
-            msg += " -- see below:\n" + record.traceback
+        traceback = getattr(record, "traceback", None)
+        if traceback:
+            msg += " -- see below:\n" + traceback
         return msg.rstrip("\n")
 
 

--- a/loggo/loggo.py
+++ b/loggo/loggo.py
@@ -8,6 +8,7 @@ from functools import wraps
 import inspect
 import logging
 import os
+import pathlib
 import sys
 import traceback
 from typing import Any, Callable, Dict, Generator, Mapping, Optional, Set, Tuple, Union
@@ -123,9 +124,11 @@ class Loggo:
         self.logger.setLevel(LOG_THRESHOLD)
         self._add_graylog_handler()
 
-        formatter = logging.Formatter("%(asctime)s\t%(message)s\t%(levelname)s", "%Y-%m-%d %H:%M:%S %Z")
+        formatter = logging.Formatter("%(asctime)s\t%(message)s\t%(levelno)s", "%Y-%m-%d %H:%M:%S %Z")
 
         if do_write:
+            # create the directory where logs are stored if it does not exist yet
+            pathlib.Path(os.path.dirname(self.logfile)).mkdir(parents=True, exist_ok=True)
             file_handler = logging.FileHandler(self.logfile, delay=True)
             file_handler.setFormatter(formatter)
             self.logger.addHandler(file_handler)

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -345,7 +345,7 @@ class TestLog(unittest.TestCase):
         mock = mock_open()
         with patch("builtins.open", mock):
             self.log(logging.INFO, "An entry in our log")
-            mock.assert_called_with(loggo.logfile, "a")
+            mock.assert_called_with(loggo.logfile, "a", encoding=None)
             self.assertTrue(os.path.isfile(loggo.logfile))
 
     def test_int_truncation(self):


### PR DESCRIPTION
don't reinvent the wheel. everything that can be handled by the `logging` module should be handled by it. reduces complexity of loggo  (and line numbers too)