### PR TITLE
Preparation for next major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This log should always be updated when doing backwards incompatible changes, res
     - Make Loggo.write_to_file() a private method.
     - Make Loggo init param `raise_logging_errors` default to True
     - Make loggo.loggo module private
+    - Reduce a Loggo object's public data members to minimum. Only `called`, `returned`, `returned_none` and `errored` remain public now.
 
 6.0.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This log should always be updated when doing backwards incompatible changes, res
     - Don't allow using @loggo.logme to decorate callables. Use @loggo instead.
     - Make Loggo.write_to_file() a private method.
     - Make Loggo init param `raise_logging_errors` default to True
+    - Make loggo.loggo module private
 
 6.0.0
 -----

--- a/loggo/__init__.py
+++ b/loggo/__init__.py
@@ -1,3 +1,3 @@
-from .loggo import Loggo  # noqa: F401
+from ._loggo import Loggo  # noqa: F401
 
 __version__ = "6.0.1"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT

--- a/loggo/_loggo.py
+++ b/loggo/_loggo.py
@@ -43,11 +43,11 @@ DATE_FORMAT = "%Y-%m-%d %H:%M:%S %Z"
 
 # Make a dummy logging.LogRecord object, so that we can inspect what
 # attributes instances of that class have.
-_dummy_log_record = logging.LogRecord("dummy_name", logging.INFO, "dummy_pathname", 1, "dummy_msg", {}, None)
-LOG_RECORD_ATTRS = vars(_dummy_log_record).keys()
+dummy_log_record = logging.LogRecord("dummy_name", logging.INFO, "dummy_pathname", 1, "dummy_msg", {}, None)
+LOG_RECORD_ATTRS = vars(dummy_log_record).keys()
 
 
-class _Formatters(TypedDict, total=False):
+class Formatters(TypedDict, total=False):
     """A dictionary of data that can be input into log messages.
 
     The keys can be used in log message forms e.g. "*Called
@@ -76,10 +76,10 @@ class _Formatters(TypedDict, total=False):
     return_type: str
 
 
-_CallableEvent = Literal["called", "errored", "returned", "returned_none"]
+CallableEvent = Literal["called", "errored", "returned", "returned_none"]
 
 
-class _LocalLogFormatter(logging.Formatter):
+class LocalLogFormatter(logging.Formatter):
     """Formatter for file logs and stdout logs."""
 
     def __init__(self) -> None:
@@ -150,12 +150,12 @@ class Loggo:
             # create the directory where logs are stored if it does not exist yet
             pathlib.Path(os.path.dirname(self.logfile)).mkdir(parents=True, exist_ok=True)
             file_handler = logging.FileHandler(self.logfile, delay=True)
-            file_handler.setFormatter(_LocalLogFormatter())
+            file_handler.setFormatter(LocalLogFormatter())
             self.logger.addHandler(file_handler)
 
         if do_print:
             print_handler = logging.StreamHandler(sys.stdout)
-            print_handler.setFormatter(_LocalLogFormatter())
+            print_handler.setFormatter(LocalLogFormatter())
             self.logger.addHandler(print_handler)
 
         self._add_graylog_handler()
@@ -309,7 +309,7 @@ class Loggo:
             privates = [key for key in param_strings if key not in bound]
 
             # add more format strings
-            more = _Formatters(
+            more = Formatters(
                 decorated=True,
                 couplet=uuid.uuid1(),
                 number_of_params=len(args) + len(kwargs),
@@ -330,7 +330,7 @@ class Loggo:
                 formatters["traceback"] = traceback.format_exc()
                 self._generate_log("errored", error, formatters, param_strings)
                 raise
-            where: _CallableEvent = "returned_none" if response is None else "returned"
+            where: CallableEvent = "returned_none" if response is None else "returned"
             # the successful return log
             if not just_errors:
                 self._generate_log(where, response, formatters, param_strings)
@@ -350,7 +350,7 @@ class Loggo:
         return params
 
     @staticmethod
-    def _make_call_signature(function: Callable, param_strings: Dict[str, str]) -> _Formatters:
+    def _make_call_signature(function: Callable, param_strings: Dict[str, str]) -> Formatters:
         """Represent the call as a string mimicking how it is written in
         Python.
 
@@ -358,7 +358,7 @@ class Loggo:
         """
         signature = "{callable}({params})"
         param_str = ", ".join(f"{k}={v}" for k, v in param_strings.items())
-        format_strings = _Formatters(
+        format_strings = Formatters(
             callable=getattr(function, "__qualname__", "unknown_callable"), params=param_str
         )
         format_strings["call_signature"] = signature.format(**format_strings)
@@ -431,7 +431,7 @@ class Loggo:
         return "({})".format(self._force_string_and_truncate(response, truncate=None, use_repr=True))
 
     def _generate_log(
-        self, where: _CallableEvent, returned: Any, formatters: _Formatters, safe_log_data: Dict[str, str]
+        self, where: CallableEvent, returned: Any, formatters: Formatters, safe_log_data: Dict[str, str]
     ) -> None:
         """Generate message, level and log data for automated logs.
 

--- a/loggo/loggo.py
+++ b/loggo/loggo.py
@@ -47,7 +47,14 @@ _dummy_log_record = logging.LogRecord("dummy_name", logging.INFO, "dummy_pathnam
 LOG_RECORD_ATTRS = vars(_dummy_log_record).keys()
 
 
-class Formatters(TypedDict, total=False):
+class _Formatters(TypedDict, total=False):
+    """A dictionary of data that can be input into log messages.
+
+    The keys can be used in log message forms e.g. "*Called
+    {call_signature}". In the final log message {call_signature} will
+    then be replaced by its value in this formatter dict.
+    """
+
     call_signature: str
     callable: str
     params: str
@@ -69,10 +76,12 @@ class Formatters(TypedDict, total=False):
     return_type: str
 
 
-CallableEvent = Literal["called", "errored", "returned", "returned_none"]
+_CallableEvent = Literal["called", "errored", "returned", "returned_none"]
 
 
-class _Formatter(logging.Formatter):
+class _LocalLogFormatter(logging.Formatter):
+    """Formatter for file logs and stdout logs."""
+
     def __init__(self) -> None:
         super().__init__("%(asctime)s\t%(message)s\t%(levelno)s", DATE_FORMAT)
 
@@ -141,12 +150,12 @@ class Loggo:
             # create the directory where logs are stored if it does not exist yet
             pathlib.Path(os.path.dirname(self.logfile)).mkdir(parents=True, exist_ok=True)
             file_handler = logging.FileHandler(self.logfile, delay=True)
-            file_handler.setFormatter(_Formatter())
+            file_handler.setFormatter(_LocalLogFormatter())
             self.logger.addHandler(file_handler)
 
         if do_print:
             print_handler = logging.StreamHandler(sys.stdout)
-            print_handler.setFormatter(_Formatter())
+            print_handler.setFormatter(_LocalLogFormatter())
             self.logger.addHandler(print_handler)
 
         self._add_graylog_handler()
@@ -300,7 +309,7 @@ class Loggo:
             privates = [key for key in param_strings if key not in bound]
 
             # add more format strings
-            more = Formatters(
+            more = _Formatters(
                 decorated=True,
                 couplet=uuid.uuid1(),
                 number_of_params=len(args) + len(kwargs),
@@ -321,7 +330,7 @@ class Loggo:
                 formatters["traceback"] = traceback.format_exc()
                 self._generate_log("errored", error, formatters, param_strings)
                 raise
-            where: CallableEvent = "returned_none" if response is None else "returned"
+            where: _CallableEvent = "returned_none" if response is None else "returned"
             # the successful return log
             if not just_errors:
                 self._generate_log(where, response, formatters, param_strings)
@@ -341,7 +350,7 @@ class Loggo:
         return params
 
     @staticmethod
-    def _make_call_signature(function: Callable, param_strings: Dict[str, str]) -> Formatters:
+    def _make_call_signature(function: Callable, param_strings: Dict[str, str]) -> _Formatters:
         """Represent the call as a string mimicking how it is written in
         Python.
 
@@ -349,7 +358,7 @@ class Loggo:
         """
         signature = "{callable}({params})"
         param_str = ", ".join(f"{k}={v}" for k, v in param_strings.items())
-        format_strings = Formatters(
+        format_strings = _Formatters(
             callable=getattr(function, "__qualname__", "unknown_callable"), params=param_str
         )
         format_strings["call_signature"] = signature.format(**format_strings)
@@ -422,7 +431,7 @@ class Loggo:
         return "({})".format(self._force_string_and_truncate(response, truncate=None, use_repr=True))
 
     def _generate_log(
-        self, where: CallableEvent, returned: Any, formatters: Formatters, safe_log_data: Dict[str, str]
+        self, where: _CallableEvent, returned: Any, formatters: _Formatters, safe_log_data: Dict[str, str]
     ) -> None:
         """Generate message, level and log data for automated logs.
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -299,9 +299,10 @@ class TestDecoration(unittest.TestCase):
 
 class TestLog(unittest.TestCase):
     def setUp(self):
+        self.logfile = "./logs/logs.txt"
         self.log_msg = "This is a message that can be used when the content does not matter."
         self.log_data = {"This is": "log data", "that can be": "used when content does not matter"}
-        self.loggo = Loggo(do_print=True, do_write=True, log_if_graylog_disabled=False)
+        self.loggo = Loggo(do_print=True, do_write=True, logfile=self.logfile, log_if_graylog_disabled=False)
         self.log = self.loggo.log
 
     def test_protected_keys(self):
@@ -329,11 +330,12 @@ class TestLog(unittest.TestCase):
 
     def test_write_to_file(self):
         """Check that we can write logs to file."""
+        expected_logfile = os.path.abspath(os.path.expanduser(self.logfile))
         mock = mock_open()
         with patch("builtins.open", mock):
             self.log(logging.INFO, "An entry in our log")
-            mock.assert_called_with(loggo.logfile, "a", encoding=None)
-            self.assertTrue(os.path.isfile(loggo.logfile))
+            mock.assert_called_with(expected_logfile, "a", encoding=None)
+            self.assertTrue(os.path.isfile(expected_logfile))
 
     def test_int_truncation(self):
         """Test that large ints in log data are truncated."""

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -18,14 +18,14 @@ class TestWithoutGraypy(unittest.TestCase):
         builtins.__import__ = self.import_orig
         import loggo
 
-        reload(loggo.loggo)
+        reload(loggo._loggo)
 
     def tests_using_graypy(self):
         import loggo
 
-        reload(loggo.loggo)
+        reload(loggo._loggo)
         loggo.Loggo()
-        self.assertEqual(loggo.loggo.graypy, None)
+        self.assertEqual(loggo._loggo.graypy, None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Set dateformat to a constant
- Start graylog handler last so we get the warning logs from it in file/stdout
- Make loggo.loggo module private so the only public things/import paths are the ones in `loggo.__init__`: `loggo.Loggo` and `loggo.__version__`. This allows us to not prefix everything with `_` in loggo.loggo module
- Make almost all data attributes of Loggo private